### PR TITLE
Csv export

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,33 +29,38 @@ Description
  whereas the interactive part of the programm uses STDERR for its output.
  Please note that all the automatic filters are executed in a strict 
  order first retaining all bibitems (with -a and -i) and afterwards 
- removing the rest according to (-r and -e)
+ removing the rest according to (-r and -e).
 
 Commandline Options
 -------------------
 
- Argument       | Function
-:--------------:|-------------------------------------------------------------------
- -cN            | Filter the bibitems by citations and remove all entries with less then N citations. (This method assumes a citations field in each bibtex entry.)
- -d             | remove duplicates from the bibtex entries based on their key. This option is combinable with every other option.
- --intersection | instead of creating the union of all files, create the intersection of all file, i.e., only add bibtex entries present in all files. This option is combinable with every other option.
- --difference   | instead of creating the union of all files, creates the difference of the first and all files, i.e., only include bibtex entries of the first file not included in any subsequent files.
- -aT            | Filter the bibitems and retain all items belonging to a certain class (i.e.: article, book, incollections). This option can be used multiple times but not in combination with other options! 
- -rT            | Filter the bibitems and remove all items belonging to a certain class (i.e.: article, book, incollections). This option can be used multiple times but not in combination with other options!
- -e"/REGEX/"    | excludes all bibitems to which this ruby regular expression applies. The expression will be evaluated for each line of a bibfile, so it is impossible evaluate a howl bibitem. This option can be used once, but combined with other automated options like -a, -r, or -i.
- -i"/REGEX/"    | includes all bibitems to which this ruby regular expression applies. The expression will be evaluated for each line of a bibfile, so it is impossible evaluate a howl bibitem. This option can be used once, but combined with other automated options like -a, -r, or -e.
- -n             | Perform an Interactive decission process showing the title, the link and the number of citations (default).
- -h             | Show this document.
- -m             | Measure the entries in the bibtex file to compute the citations min, max, and median as well as the total number of entries. This works also in combination with automatic filters but not with the interactive filter.
- --size         | only emit the number of bibitems. This option implies -m.
- --min          | only emit the minimum of the citation count. This option implies -m.
- --max          | only emit the maximum of the citation count. This option implies -m.
- --median       | only emit the median of the citation count. This option implies -m.
- --files        | only emit the number of referenced files. This option implies -m.
- -t             | creates output of measures in the CSV format with count; citations median, min, max. This option implies -m.
- -l             | add the total number of files referenced in the bibtex file to the measured entries. This option implies -m and can be combined with -t.
- -v             | produces verbose output.
- -V             | Shows the version number.
+ Argument           | Function
+:------------------:|-------------------------------------------------------------------
+ -cN                | Filter the bibitems by citations and remove all entries with less then N citations. (This method assumes a citations field in each bibtex entry.)
+ -d                 | remove duplicates from the bibtex entries based on their key. This option is combinable with every other option.
+ --intersection     | instead of creating the union of all files, create the intersection of all file, i.e., only add bibtex entries present in all files. This option is combinable with every other option.
+ --difference       | instead of creating the union of all files, creates the difference of the first and all files, i.e., only include bibtex entries of the first file not included in any subsequent files.
+ -aT                | Filter the bibitems and retain all items belonging to a certain class (i.e.: article, book, incollections). This option can be used multiple times but not in combination with other options! 
+ -rT                | Filter the bibitems and remove all items belonging to a certain class (i.e.: article, book, incollections). This option can be used multiple times but not in combination with other options!
+ -e"/REGEX/"        | excludes all bibitems to which this ruby regular expression applies. The expression will be evaluated for each line of a bibfile, so it is impossible evaluate a howl bibitem. This option can be used once, but combined with other automated options like -a, -r, or -i.
+ -i"/REGEX/"        | includes all bibitems to which this ruby regular expression applies. The expression will be evaluated for each line of a bibfile, so it is impossible evaluate a howl bibitem. This option can be used once, but combined with other automated options like -a, -r, or -e.
+ -n                 | perform an Interactive decission process showing the title, the link and the number of citations (default).
+ -h                 | show this document.
+ -m                 | Measure the entries in the bibtex file to compute the citations min, max, and median as well as the total number of entries. This works also in combination with automatic filters but not with the interactive filter.
+ --size             | only emit the number of bibitems. This option implies -m.
+ --min              | only emit the minimum of the citation count. This option implies -m.
+ --max              | only emit the maximum of the citation count. This option implies -m.
+ --median           | only emit the median of the citation count. This option implies -m.
+ --files            | only emit the number of referenced files. This option implies -m.
+ -t                 | creates output of measures in the CSV format with count; citations median, min, max. This option implies -m.
+ -l                 | add the total number of files referenced in the bibtex file to the measured entries. This option implies -m and can be combined with -t.
+ -csv               | generates a CSV from the bibtex entries. The default fields to export are "Key, Title, Author". Conflicts with -m.
+ --fields"[FIELD]+" |  Extracts the given set of fields when creating a CSV file. FIELD is a comma seperated list of bibtex fields (case insensitive). This option implies -csv.
+ --sep"SEPERATOR"   | create the CSV using the specified SEPERATOR (default is comma). This option implies -csv.
+ --empty"STRING"    | Shows empty fields as STRING displayed in the CSV output. This option implies -csv.
+ --classes"[PATH]+" | Not implemented yet. This option implies -csv.
+ -v                 | produces verbose output.
+ -V                 | shows the version number.
 
 Usage
 -----

--- a/README.md
+++ b/README.md
@@ -55,10 +55,10 @@ Commandline Options
  -t                 | creates output of measures in the CSV format with count; citations median, min, max. This option implies -m.
  -l                 | add the total number of files referenced in the bibtex file to the measured entries. This option implies -m and can be combined with -t.
  -csv               | generates a CSV from the bibtex entries. The default fields to export are "Key, Title, Author". Conflicts with -m.
- --fields"[FIELD]+" |  Extracts the given set of fields when creating a CSV file. FIELD is a comma seperated list of bibtex fields (case insensitive). This option implies -csv.
- --sep"SEPERATOR"   | create the CSV using the specified SEPERATOR (default is comma). This option implies -csv.
- --empty"STRING"    | Shows empty fields as STRING displayed in the CSV output. This option implies -csv.
- --classes"[PATH]+" | Not implemented yet. This option implies -csv.
+ --fields"[FIELD]+" |  Extracts the given set of fields when creating a CSV file. FIELD is a comma separated list of bibtex fields (case insensitive). This option implies -csv.
+ --sep"SEPERATOR"   | create the CSV using the specified SEPERATOR (default is semi colon). This option implies -csv.
+ --empty"STRING"    | shows empty fields as STRING displayed in the CSV output. This option implies -csv.
+ --classes"[PATH]+" | extract the entries from a classification stored in the classes attribute. PATH is a comma separated list of path expressions with dot, e.g., `Meta Data.Kind`. If the PATH leads to a complex structure, it is flattened and emitted as a comma separated list. This option implies -csv.
  -v                 | produces verbose output.
  -V                 | shows the version number.
 

--- a/bibfilter.rb
+++ b/bibfilter.rb
@@ -1,6 +1,8 @@
 #!/bin/ruby
 # encoding : utf-8
 
+require 'csv'
+
 Version="1.3"
 Documentation=<<EOS
 NAME
@@ -79,6 +81,18 @@ OPTIONS
        measured entries. This option implies -m.
  -t    creates output of measures in the CSV format with count;
        citations median, min, max. This option implies -m.
+ -csv  generates a CSV from the bibtex entries. The default fields to export are
+       "Key, Title, Author".
+ --fields"[Field]+"
+       Extracts the given set of fields when creating a CSV file. Field is a 
+       comma seperated list of bibtex fields (case insensitive). 
+       This option implies -csv.
+ --sepSEPERATOR
+       create the CSV using the specified SEPERATOR. This option implies -csv.
+ --empty"STRING"
+       shows empty fields as STRING displayed in the CSV output. This option implies -csv.
+ --classes"[Path+]"
+       Not implemented yet. This option implies -csv.       
  -v    produces verbose output.
  -V    Shows the version number.
 
@@ -135,6 +149,11 @@ onlyemit=nil
 removeduplicates=false
 intersection=false
 difference=false
+# Parameters for CSV output
+csvexport=false
+fields=["Key","Author","Title"]
+emptyField="None"
+seperator=","
 
 ARGV.each do|x| 
  case x
@@ -186,6 +205,15 @@ ARGV.each do|x|
    summary=true
    table=true
    key="-a"
+  when /^-csv$/
+    csvexport=true;
+    key="-a"
+  when /^--sep(.+)$/
+    seperator=$1
+  when /^--empty(.*)$/
+    emptyField=$1.strip    
+  when /^--fields([a-zA-Z,]+)$/
+    fields=$1.strip.split(",").map{|f| f.strip}
   when /^-v$/
    verbose=true
   else
@@ -217,6 +245,11 @@ end
 
 if intersection and difference
   $stderr.puts "Options --intersection and --difference are mutual exclusive, only use one of them"
+  exit(4)
+end
+
+if summary and csvexport
+  $stderr.puts "Options -m measure and -csv are mutual exclusive, only use one of them"
   exit(4)
 end
 
@@ -332,7 +365,7 @@ if key=="-n" and (not predicate.nil?)
 else
  unless predicate.nil?
   filtered=bibitems.select(&predicate)
-  filtered.each{|x| puts x} unless summary
+  filtered.each{|x| puts x} unless summary or csvexport
  end
 end
 
@@ -365,5 +398,37 @@ if summary
   end
 end
 
+if csvexport
+  result=CSV.generate("",col_sep: seperator) do |csv|
+    $stderr.puts "export csv"
+    csv << fields
+    fieldMatcher=fields.map do|f|
+      s=f.strip.downcase
+      [s,Regexp.new(s+".*=[^{]*[\{\"](.*)[\}\"][,]?$")]
+    end
+    filtered.each do|bib|
+      row=[]
+      fieldMatcher.each do|field,fieldreg|
+        if field=="key"
+          if bib.find{|l| /^@.*{(.+),/ =~ l }
+            row << $1.to_s.strip
+          else
+            $stderr.puts "[ERROR]: Could not find bibkey in:"
+            $stderr.puts bib
+            row << emptyField
+          end
+        else
+          if bib.find{|l| fieldreg =~ l }
+            row << $1.to_s.strip
+          else 
+            row << emptyField
+          end
+        end
+      end
+      csv << row
+    end
+  end
+  puts result
+end
 
 


### PR DESCRIPTION
The following update adds support for exporting a CSV file from given BibTex files, including the following features:
* works in combination with all filters
* permits declaring the fields to export and string indicating empty cells (default: `None`)
* permits additionally extracting fields from a given SLR-Toolkit classification (must be stored in a `classes` field)